### PR TITLE
Add "Ignore travel for interventions" toggle and wire through scheduler

### DIFF
--- a/frontend/app/api/calculate/route.ts
+++ b/frontend/app/api/calculate/route.ts
@@ -16,6 +16,7 @@ type Inputs = {
   useMelatonin: boolean
   useLightDark: boolean
   useExercise: boolean
+  ignoreTravelInterventions: boolean
   preDays: number
   adjustmentStart: 'after_arrival' | 'travel_start' | 'precondition'
 }

--- a/frontend/app/page.module.css
+++ b/frontend/app/page.module.css
@@ -5,6 +5,8 @@
 .row select{min-width:200px}
 .row label{font-size:12px;color:#444;margin-right:6px}
 .row input[type="number"],.row input[type="time"],.row input[type="datetime-local"],.row select{padding:6px 8px;border:1px solid #ddd;border-radius:8px;background:#fff}
+.toggleButton{padding:6px 10px;border-radius:999px;border:1px solid #d1d5db;background:#fff;color:#111;font-size:12px;cursor:pointer}
+.toggleButtonActive{background:#111;color:#fff;border-color:#111}
 .adjustmentControl{display:flex;align-items:center;gap:6px}
 .adjustmentControl label{margin-right:0}
 .adjustmentControl select{min-width:200px}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -98,6 +98,7 @@ export default function Page() {
   const [useMelatonin, setUseMelatonin] = useState(true)
   const [useLightDark, setUseLightDark] = useState(true)
   const [useExercise, setUseExercise] = useState(false)
+  const [ignoreTravelInterventions, setIgnoreTravelInterventions] = useState(false)
   const [adjustmentStart, setAdjustmentStart] = useState<AdjustmentStartOption>('after_arrival')
   const [preDays, setPreDays] = useState(2)
   const [preDaysStr, setPreDaysStr] = useState<string>(String(2))
@@ -197,6 +198,7 @@ export default function Page() {
           useMelatonin,
           useLightDark,
           useExercise,
+          ignoreTravelInterventions,
           adjustmentStart,
           preDays,
         })
@@ -261,6 +263,14 @@ export default function Page() {
           <label><input type="checkbox" checked={useMelatonin} onChange={e => setUseMelatonin(e.target.checked)} /> Melatonin</label>
           <label><input type="checkbox" checked={useLightDark} onChange={e => setUseLightDark(e.target.checked)} /> Light/Dark</label>
           <label><input type="checkbox" checked={useExercise} onChange={e => setUseExercise(e.target.checked)} /> Exercise</label>
+          <button
+            type="button"
+            className={`${styles.toggleButton} ${ignoreTravelInterventions ? styles.toggleButtonActive : ''}`}
+            aria-pressed={ignoreTravelInterventions}
+            onClick={() => setIgnoreTravelInterventions(prev => !prev)}
+          >
+            Ignore travel for interventions
+          </button>
           <div className={styles.adjustmentControl}>
             <label htmlFor="adjustmentStart">Start adjustments</label>
             <select id="adjustmentStart" value={adjustmentStart} onChange={e => setAdjustmentStart(e.target.value as AdjustmentStartOption)}>
@@ -494,7 +504,7 @@ export default function Page() {
                     comment: reportComment,
                     inputs: {
                       originOffset, destOffset, originSleepStart, originSleepEnd, destSleepStart, destSleepEnd,
-                      travelStart, travelEnd, useMelatonin, useLightDark, useExercise, adjustmentStart, preDays
+                      travelStart, travelEnd, useMelatonin, useLightDark, useExercise, ignoreTravelInterventions, adjustmentStart, preDays
                     },
                     data: events ?? null,
                     userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown',

--- a/jetlag_core/cli.py
+++ b/jetlag_core/cli.py
@@ -48,6 +48,7 @@ def main() -> int:
             use_melatonin=bool(data["useMelatonin"]),
             use_exercise=bool(data["useExercise"]),
             use_light_dark=bool(data["useLightDark"]),
+            ignore_travel_interventions=bool(data.get("ignoreTravelInterventions", False)),
             precondition_days=int(data.get("preDays", 0)),
             adjustment_start=str(data.get("adjustmentStart", "after_arrival")),
         )


### PR DESCRIPTION
### Motivation
- Provide a way for users to allow scheduled interventions (light, melatonin, exercise, dark) to be considered even when they overlap the travel interval so plans can explicitly ignore travel windows when desired.

### Description
- Add a UI toggle `Ignore travel for interventions` with state `ignoreTravelInterventions` and styles in `frontend/app/page.tsx` and `frontend/app/page.module.css` and include the flag in the feedback payload.
- Propagate the flag through the API type (`frontend/app/api/calculate/route.ts`) and the Python CLI (`jetlag_core/cli.py`) into the scheduler input as `ignore_travel_interventions`.
- Extend `create_jet_lag_timetable` in `jetlag_core/schedule.py` with the new parameter and adapt scheduling logic to honor it by allowing a `first_window` when requested, changing `no_intervention_window` handling, refining short-shift (`small_shift`) behavior, assigning `day_index` for events, and improving sleep-window iteration.
- Add a test `test_ignore_travel_interventions_allows_intervention_during_travel` and adjust related expectations in `tests/test_schedule.py` to cover the new behavior.

### Testing
- Ran `pytest` and all tests passed (`20 passed`).
- Ran `npm run lint`, which prompted for ESLint configuration in this environment and did not complete non-interactively (manual configuration required).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979d35b8818832ca1c10be4e44718ae)