### PR TITLE
Fix legend print colors

### DIFF
--- a/frontend/app/page.module.css
+++ b/frontend/app/page.module.css
@@ -31,6 +31,8 @@
   .svgGridContainer{overflow:visible;height:auto}
   .svgGrid{width:100%;height:auto}
   .printBannerQr{width:120px;height:120px}
+  .legend{print-color-adjust:exact;-webkit-print-color-adjust:exact}
+  .legendBox::before{print-color-adjust:exact;-webkit-print-color-adjust:exact}
 }
 .printBanner{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:12px 16px;border:1px solid #e5e7eb;border-radius:12px;background:#fff;margin-bottom:16px}
 .printBannerText{display:flex;flex-direction:column;gap:4px;font-size:12px;color:#374151}


### PR DESCRIPTION
### Motivation
- Legend swatches printed as blank/washed-out boxes, so printed output must preserve their intended colors.

### Description
- Add `print-color-adjust: exact` and `-webkit-print-color-adjust: exact` to `.legend` and `.legendBox::before` in `frontend/app/page.module.css` to force accurate color reproduction when printing.

### Testing
- Started the dev server with `npm run dev` and captured a print-mode screenshot with Playwright saved to `artifacts/legend-print.png` (success); `npm run lint` was run and failed because ESLint is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a5be718f8832cbbc833edffb33543)