### PR TITLE
Update Jetlag domain references to jetlag.lysiyo.com

### DIFF
--- a/frontend/app/Analytics.tsx
+++ b/frontend/app/Analytics.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react'
 import { consentEventName, readStoredConsent } from './analyticsConsent'
 
 const googleAnalyticsId = 'G-KS1XTLYRTF'
+const analyticsDomain = 'jetlag.lysiyo.com'
 
 export default function Analytics() {
   const [hasConsent, setHasConsent] = useState(false)
@@ -42,7 +43,7 @@ export default function Analytics() {
 function gtag(){dataLayer.push(arguments);}
 gtag('js', new Date());
 
-gtag('config', '${googleAnalyticsId}');`}
+gtag('config', '${googleAnalyticsId}', { cookie_domain: '${analyticsDomain}' });`}
       </Script>
     </>
   )

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -12,7 +12,7 @@ const OFFSET_STEP = 0.25
 
 const DEFAULT_ORIGIN_TZ = 'America/New_York'
 const DEFAULT_DEST_TZ = 'Europe/Paris'
-const SITE_URL = 'https://jetlag.jumpingcrab.com'
+const SITE_URL = 'https://jetlag.lysiyo.com'
 
 const FALLBACK_TIMEZONES = [
   'Pacific/Midway',
@@ -231,13 +231,13 @@ export default function Page() {
       <div className={styles.printBanner}>
         <div className={styles.printBannerText}>
           <strong className={styles.printBannerTitle}>Jet Lag Planner</strong>
-          <span>jetlag.jumpingcrab.com</span>
+          <span>jetlag.lysiyo.com</span>
           <span>Scan to plan your next trip.</span>
         </div>
         <img
           className={styles.printBannerQr}
           src={`https://api.qrserver.com/v1/create-qr-code/?size=140x140&data=${encodeURIComponent(SITE_URL)}`}
-          alt="QR code for jetlag.jumpingcrab.com"
+          alt="QR code for jetlag.lysiyo.com"
           loading="lazy"
         />
       </div>

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://jetlag.jumpingcrab.com/sitemap.xml
+Sitemap: https://jetlag.lysiyo.com/sitemap.xml

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://jetlag.jumpingcrab.com/</loc>
+    <loc>https://jetlag.lysiyo.com/</loc>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
### Motivation
- Consolidate public-facing references to the new hostname so users, QR codes, sitemap and analytics target `jetlag.lysiyo.com`.

### Description
- Update the site URL constant to `https://jetlag.lysiyo.com` in `frontend/app/page.tsx` and update the print banner text and QR alt text accordingly.
- Change the sitemap entry in `frontend/public/sitemap.xml` and the `Sitemap:` link in `frontend/public/robots.txt` to the new domain.
- Add `analyticsDomain = 'jetlag.lysiyo.com'` and pass `{ cookie_domain: 'jetlag.lysiyo.com' }` to `gtag('config', ...)` in `frontend/app/Analytics.tsx` so Google Analytics cookies are scoped to the new hostname.

### Testing
- Searched codebase for existing domain references with `rg` to locate affected files and updated the ones found, which succeeded.
- Ran `npm install` in `frontend` which completed and reported packages up to date.
- Attempted `npm run lint` which failed because ESLint is not installed; attempting `npm install --save-dev eslint` failed with a 403 to the npm registry so linting could not be completed.
- Started the frontend with `npm run dev` which compiled and served the app, and a Playwright-based page load + screenshot of `http://127.0.0.1:3000` completed successfully (screenshot artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a699579c8832c946a5310da59fbcd)